### PR TITLE
Adds ability to decode multiple docs in stream

### DIFF
--- a/readerc.go
+++ b/readerc.go
@@ -4,6 +4,17 @@ import (
 	"io"
 )
 
+func yaml_parser_remaining_buffer(parser *yaml_parser_t) []byte {
+	if parser.unread > 0 {
+		offset := len(parser.buffer) - parser.unread
+		if int(parser.buffer[offset]) == 0 {
+			return []byte{}
+		}
+		return parser.buffer[offset:]
+	}
+	return []byte{}
+}
+
 // Set the reader error and return 0.
 func yaml_parser_set_reader_error(parser *yaml_parser_t, problem string, offset int, value int) bool {
 	parser.error = yaml_READER_ERROR


### PR DESCRIPTION
This adds the ability to decode multiple documents from the YAML stream. I ended up creating a new function `UnmarshalDocuments()` since YAML can have arrays arbitrarily nested and there was no way to discern by the `out` parameter whether the user is requesting multiple documents or a single doc with a nested array structure -- both of which result in a `slice`.