### PR TITLE
Handle comments at beginning of document

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -140,7 +140,6 @@ func (p *parser) document() *node {
 	p.doc = n
 	p.skip()
 	next := p.parse()
-	// Chomp all comments, as they can't be part of the top-level YAML structure
 	for next.kind == commentNode {
 		n.children = append(n.children, next)
 		next = p.parse()

--- a/decode.go
+++ b/decode.go
@@ -142,6 +142,7 @@ func (p *parser) document() *node {
 	next := p.parse()
 	// Chomp all comments, as they can't be part of the top-level YAML structure
 	for next.kind == commentNode {
+		n.children = append(n.children, next)
 		next = p.parse()
 	}
 	n.children = append(n.children, next)
@@ -332,12 +333,25 @@ func (d *decoder) unmarshal(n *node, out reflect.Value, prependComments []MapIte
 }
 
 func (d *decoder) document(n *node, out reflect.Value) (good bool) {
-	if len(n.children) == 1 {
-		d.doc = n
-		d.unmarshal(n.children[0], out, nil)
-		return true
+	var prependComments []MapItem
+	var hasDocument bool
+	for _, node := range n.children {
+		if node.kind == commentNode {
+			prependComments = append(prependComments, MapItem{
+				Key: Comment{
+					Value: node.value,
+				},
+				Value: nil,
+			})
+		} else if (!hasDocument) {
+			d.doc = n
+			d.unmarshal(node, out, prependComments)
+			hasDocument = true
+		} else {
+			return false
+		}
 	}
-	return false
+	return hasDocument
 }
 
 func (d *decoder) alias(n *node, out reflect.Value) (good bool) {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -7,6 +7,7 @@ import (
 
 
 var COMMENT_1_IN = []byte(`---
+# begin
 a:
  # foo
  # bar
@@ -29,6 +30,12 @@ d:
 `)
 var COMMENT_1_TREE = []yaml.MapSlice{
 	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   yaml.Comment{
+				Value: " begin",
+			},
+			Value: nil,
+		},
 		yaml.MapItem{
 			Key:   "a",
 			Value: yaml.MapSlice{
@@ -107,7 +114,8 @@ var COMMENT_1_TREE = []yaml.MapSlice{
 		},
 	},
 }
-var COMMENT_1_OUT = []byte(`a:
+var COMMENT_1_OUT = []byte(`# begin
+a:
   # foo
   # bar
   b: null

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -128,6 +128,43 @@ d:
 # e
 `)
 
+var COMMENT_2_IN = []byte(`---
+a:
+    ## foo
+    ##
+    b:
+`)
+var COMMENT_2_TREE = []yaml.MapSlice{
+	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   "a",
+			Value: yaml.MapSlice{
+				yaml.MapItem{
+					Key:   yaml.Comment{
+						Value: "# foo",
+					},
+					Value: nil,
+				},
+				yaml.MapItem{
+					Key:   yaml.Comment{
+						Value: "#",
+					},
+					Value: nil,
+				},
+				yaml.MapItem{
+					Key:   "b",
+					Value: nil,
+				},
+			},
+		},
+	},
+}
+var COMMENT_2_OUT = []byte(`a:
+  ## foo
+  ##
+  b: null
+`)
+
 
 func (s *S) TestCommentMoving1(c *C) {
 	var data []yaml.MapSlice
@@ -137,4 +174,15 @@ func (s *S) TestCommentMoving1(c *C) {
 	out, err := (&yaml.YAMLMarshaler{Indent: 2}).Marshal(data[0])
 	c.Assert(err, DeepEquals, nil)
 	c.Assert(out, DeepEquals, COMMENT_1_OUT)
+}
+
+
+func (s *S) TestCommentParsing(c *C) {
+	var data []yaml.MapSlice
+	err := (yaml.CommentUnmarshaler{}).UnmarshalDocuments(COMMENT_2_IN, &data)
+	c.Assert(err, DeepEquals, nil)
+	c.Assert(data, DeepEquals, COMMENT_2_TREE)
+	out, err := (&yaml.YAMLMarshaler{Indent: 2}).Marshal(data[0])
+	c.Assert(err, DeepEquals, nil)
+	c.Assert(out, DeepEquals, COMMENT_2_OUT)
 }


### PR DESCRIPTION
I realized that with the changes from #8 it should also be possible to handle comments at the beginning of a document.