### PR TITLE
Fix scanning comments at beginning of YAML file when it does not start with `---`

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -38,11 +38,12 @@ type parser struct {
 	doc    *node
 }
 
-func newParser(b []byte) *parser {
+func newParser(b []byte, parse_comments bool) *parser {
 	p := parser{}
 	if !yaml_parser_initialize(&p.parser) {
 		panic("failed to initialize YAML emitter")
 	}
+	p.parser.parse_comments = parse_comments
 
 	if len(b) == 0 {
 		b = []byte{'\n'}

--- a/yaml.go
+++ b/yaml.go
@@ -47,8 +47,7 @@ type CommentUnmarshaler struct{}
 func (u CommentUnmarshaler) Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
 	d := newDecoder()
-	p := newParser(in)
-	p.parser.parse_comments = true
+	p := newParser(in, true)
 	defer p.destroy()
 	node := p.parse()
 	if node != nil {
@@ -81,10 +80,7 @@ func unmarshalDocuments(in []byte, out interface{}, withComments bool) (err erro
 	svt := sv.Type().Elem()
 	var p *parser
 	for {
-		p = newParser(in)
-		if withComments {
-			p.parser.parse_comments = true
-		}
+		p = newParser(in, withComments)
 		node := p.parse()
 		if node != nil {
 			v := reflect.New(svt).Elem()
@@ -144,7 +140,7 @@ func unmarshalDocuments(in []byte, out interface{}, withComments bool) (err erro
 func Unmarshal(in []byte, out interface{}) (err error) {
 	defer handleErr(&err)
 	d := newDecoder()
-	p := newParser(in)
+	p := newParser(in, false)
 	defer p.destroy()
 	node := p.parse()
 	if node != nil {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -136,7 +136,7 @@ d:
 # e
 `)
 
-var COMMENT_2_IN = []byte(`---
+var COMMENT_2_IN = []byte(`# beginning
 a:
     ## foo
     ##
@@ -144,6 +144,12 @@ a:
 `)
 var COMMENT_2_TREE = []yaml.MapSlice{
 	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   yaml.Comment{
+				Value: " beginning",
+			},
+			Value: nil,
+		},
 		yaml.MapItem{
 			Key:   "a",
 			Value: yaml.MapSlice{
@@ -167,7 +173,8 @@ var COMMENT_2_TREE = []yaml.MapSlice{
 		},
 	},
 }
-var COMMENT_2_OUT = []byte(`a:
+var COMMENT_2_OUT = []byte(`# beginning
+a:
   ## foo
   ##
   b: null


### PR DESCRIPTION
When a document starts with a comment and not with `---`, it is currently skipped.

This is because `parse_comments` is only set in `yaml.go` *after* the token queue is non-empty.

(Also adds a test to prevent regressions.)