### PR TITLE
Fix Unicode count problem when getting remaining bytes from parser

### DIFF
--- a/readerc.go
+++ b/readerc.go
@@ -6,7 +6,7 @@ import (
 
 func yaml_parser_remaining_bytes(parser *yaml_parser_t) []byte {
 	if parser.unread > 0 {
-		offset := len(parser.buffer) - parser.unread
+		offset := parser.buffer_pos
 		if int(parser.buffer[offset]) == 0 {
 			return []byte{}
 		}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -180,6 +180,42 @@ a:
   b: null
 `)
 
+var COMMENT_3_IN = []byte(`hello: world
+---
+hello: world
+# ✅
+---
+hello: world
+`)
+var COMMENT_3_TREE = []yaml.MapSlice{
+	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   "hello",
+			Value: "world",
+		},
+	},
+	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   "hello",
+			Value: "world",
+		},
+		yaml.MapItem{
+			Key:   yaml.Comment{
+				Value: " ✅",
+			},
+			Value: nil,
+		},
+	},
+	yaml.MapSlice{
+		yaml.MapItem{
+			Key:   "hello",
+			Value: "world",
+		},
+	},
+}
+var COMMENT_3_OUT = []byte(`hello: world
+# ✅
+`)
 
 func (s *S) TestCommentMoving1(c *C) {
 	var data []yaml.MapSlice
@@ -200,4 +236,14 @@ func (s *S) TestCommentParsing(c *C) {
 	out, err := (&yaml.YAMLMarshaler{Indent: 2}).Marshal(data[0])
 	c.Assert(err, DeepEquals, nil)
 	c.Assert(out, DeepEquals, COMMENT_2_OUT)
+}
+
+func (s *S) TestCommentUnicode(c *C) {
+	var data []yaml.MapSlice
+	err := (yaml.CommentUnmarshaler{}).UnmarshalDocuments(COMMENT_3_IN, &data)
+	c.Assert(err, DeepEquals, nil)
+	c.Assert(data, DeepEquals, COMMENT_3_TREE)
+	out, err := (&yaml.YAMLMarshaler{Indent: 2}).Marshal(data[1])
+	c.Assert(err, DeepEquals, nil)
+	c.Assert(out, DeepEquals, COMMENT_3_OUT)
 }


### PR DESCRIPTION
Fixes mozilla/sops#742.

I'm not sure whether this is entirely correct though. It does fix the problem for the YAML document in the sops issue, but I don't know if there are larger documents where this fails.